### PR TITLE
SIANXKE-382: update python and django versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,27 +8,30 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.7'
-          - '3.8'
           - '3.9'
-          - '3.10'
-        django-version:
-          - '3.2'
-        djangorestframework-version:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
+        django-version:
+          - '4.2'
+          - '5.0'
+          - '5.1'
+        djangorestframework-version:
+          - '3.15'
         exclude:
-          - django-version: '3.1'
-            djangorestframework-version: '3.10'
-          - django-version: '3.2'
-            djangorestframework-version: '3.10'
+          - python-version: '3.9'
+            django-version: '5.0'
+            djangorestframework-version: '3.15'
+          - python-version: '3.9'
+            django-version: '5.1'
+            djangorestframework-version: '3.15'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e .
 
 # Development dependencies
-flake8>=3.9,<3.10
+flake8>=7.1,<7.2
 coverage>=7.2,<7.4
 setuptools>=42
 wheel>=0.37
@@ -14,11 +14,10 @@ isort>=5.10,<5.11
 black>=22.6.0,<22.7
 
 # TestApp dependencies
-django>=3.2,<4
-djangorestframework>=3.13,<4
+django>=4.2,<6
+djangorestframework>=3.15,<4
 python-magic>=0.4.18
 rest-framework-generic-relations>=2.0.0
 django-filter>=21.1,<22
 
-# fix importlib version to avoid "AttributeError: 'EntryPoints' object has no attribute 'get'" with flake8
-importlib-metadata<5.0
+importlib-metadata>=8.5,<8.6

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,10 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )


### PR DESCRIPTION
Adding support for Python versions 3.11,  3.12 and 3.13, Django versions 4.2,  5.0 and 5.1, Django Rest Framework 3.15.

Dropping support for Python versions 3.7 and 3.8, Django version 3.8, Django Rest Framework versions 3.10-3.14.
