### PR TITLE
SIANXKE-380: avoid file deletion before Attachment removal

### DIFF
--- a/drf_attachments/handlers.py
+++ b/drf_attachments/handlers.py
@@ -1,5 +1,3 @@
-import os
-
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 

--- a/drf_attachments/models/models.py
+++ b/drf_attachments/models/models.py
@@ -145,7 +145,6 @@ class Attachment(Model):
         self.set_default_context()  # set the default context if yet empty (and if default is defined)
         self.validate_file()  # validate the file and its mime_type, extension and size
         self.manage_uniqueness()  # remove any other Attachments for content_objects with
-        self.cleanup_file()  # remove the old file of a changed Attachment
 
     def set_default_context(self):
         """Set context to settings.ATTACHMENT_DEFAULT_CONTEXT (if defined) if it's still empty"""
@@ -313,20 +312,3 @@ class Attachment(Model):
                 remove_file(attachment.file.path)
 
             to_delete.delete()
-
-    def cleanup_file(self):
-        """
-        If an Attachment is updated and receives a new file, remove the previous file from the storage
-        """
-        if self.pk:
-            try:
-                # on update delete the old file if a new one was inserted
-                # (delete_orphan only removes image on deletion of the whole attachment instance)
-                old_instance = Attachment.objects.get(pk=self.pk)
-
-                # on update delete the old file if a new one was inserted
-                if old_instance.file != self.file:
-                    remove_file(old_instance.file.path)
-            except Attachment.DoesNotExist:
-                # Do nothing if Attachment does not yet exist in DB
-                pass

--- a/drf_attachments/utils.py
+++ b/drf_attachments/utils.py
@@ -36,6 +36,7 @@ def remove_file(file_path, raise_exceptions=False):
 def get_api_attachment_url(attachment_pk):
     return reverse("attachment-download", kwargs={"pk": attachment_pk})
 
+
 def get_admin_attachment_url(attachment_pk):
     return reverse(
         "admin:drf_attachments_attachment_download",

--- a/tests/testapp/tests/test_api.py
+++ b/tests/testapp/tests/test_api.py
@@ -230,6 +230,7 @@ class TestApi(TestCase):
         self.assertEqual(1, attachments.count())
         attachment = attachments[0]
         first_attachment_file_path = attachment.file.path
+        self.assertTrue(os.path.isfile(first_attachment_file_path))
 
         # check diagram model
         diagram_attachments = self.diagram.attachments.all()
@@ -327,13 +328,17 @@ class TestApi(TestCase):
             content_object=self.file,
             file_name=DemoFile.PDF,
         )
+        attachment = Attachment.objects.first()
+        attachment_file_path = attachment.file.path
+        self.assertTrue(os.path.isfile(attachment_file_path))
 
         # delete the File model
         response = self.client.delete(f"/api/file/{self.file.pk}/")
         self.assertEqual(HTTP_204_NO_CONTENT, response.status_code, response.content)
 
-        # check that the attachment was deleted as well
+        # check that the attachment and its file were deleted as well
         self.assertEqual(0, len(Attachment.objects.all()))
+        self.assertFalse(os.path.isfile(attachment_file_path))
 
     def test_physical_file_is_deleted_with_content_object(self):
         # add an attachment to File model


### PR DESCRIPTION
This fix prevents the stored file from being deleted prematurely.
The previous version would delete the file even if a following validation (e.g. from another model within an admin form) would fail afterwards - which resulted in the attachment instance still existing in the db, but the referred file being gone (irrevocably).